### PR TITLE
Update to llvmorg 13.0.1 rc1

### DIFF
--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -25,7 +25,7 @@ jobs:
       with:
         owner: llvm
         repo: llvm-project
-        excludes: prerelease, draft
+        excludes: draft #, prerelease
 
     - name: Docker metadata
       id: meta

--- a/llvm/portfile.cmake
+++ b/llvm/portfile.cmake
@@ -20,7 +20,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO llvm/llvm-project
     REF ${LLVM_VERSION}
-    SHA512 8004c05d32b9720fb3391783621690c1df9bd1e97e72cbff9192ed88a84b0acd303b61432145fa917b5b5e548c8cee29b24ef8547dcc8677adf4816e7a8a0eb2
+    SHA512 d487bfc9b898ad0046e0c94338d7757d8a05a1a84d683abfbc9ed4994c6d12caf88fd18575225e284070fc67b3ac0970ca6639e61b1a7cc2948b216a5364a22d
     HEAD_REF main
     PATCHES
         0001-Merged-PR-2213-mlir-Plumb-OpenMP-dialect-attributes-.patch

--- a/llvm/vcpkg.json
+++ b/llvm/vcpkg.json
@@ -1,6 +1,6 @@
 {
     "name": "accera-llvm",
-    "version-string": "13.0.0",
+    "version-string": "13.0.1-rc1",
     "description": "LLVM Compiler Infrastructure for Accera.",
     "homepage": "https://llvm.org",
     "supports": "!uwp"


### PR DESCRIPTION
Enable pre-releases for canary LLVM images.